### PR TITLE
Adds optional 'quality' param to allow lossy jpeg output

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,20 @@ ImageOptimizer.new('path/to/file.png').optimize
 
 #### Optimize JPEG formats:
 
-jpegoptim provides lossless optimization for JPEG files based on optimizing the Huffman tables.
+jpegoptim provides lossless optimization for JPEG files based on optimizing the Huffman tables. all jpegs will be progressively optimized for a better web experience
 
 ```ruby
 ImageOptimizer.new('path/to/file.jpg').optimize
 ```
+
+##### Lossy JPEG optimization
+
+Pass an optional 'quality' parameter to target a specific JPG quality level (0-100), or pass -1 for lossless optimization. PNGs will ignore the quality setting
+
+```ruby
+ImageOptimizer.new('path/to/file.jpg', 80).optimize
+```
+
 
 ## Contributing
 

--- a/lib/image_optimizer.rb
+++ b/lib/image_optimizer.rb
@@ -4,13 +4,15 @@ require "image_optimizer/png_optimizer"
 
 class ImageOptimizer
   attr_reader :path
+  attr_reader :quality
 
-  def initialize(path)
+  def initialize(path, quality=-1)
     @path = path
+    @quality = quality
   end
 
   def optimize
-    JPEGOptimizer.new(path).optimize
+    JPEGOptimizer.new(path, quality).optimize
     PNGOptimizer.new(path).optimize
   end
 end

--- a/lib/image_optimizer/jpeg_optimizer.rb
+++ b/lib/image_optimizer/jpeg_optimizer.rb
@@ -1,9 +1,11 @@
 class ImageOptimizer
   class JPEGOptimizer
     attr_reader :path
+    attr_reader :quality
 
-    def initialize(path)
+    def initialize(path, quality=-1)
       @path = path
+      @quality = quality
     end
 
     def optimize
@@ -27,8 +29,14 @@ class ImageOptimizer
     end
 
     def optimize_jpeg
-      system "#{jpeg_optimizer_bin} -f --strip-all #{path}"
-    end
+      if quality < 0
+        system "#{jpeg_optimizer_bin} -f --strip-all --all-progressive #{path}"
+      elsif quality > 100
+        warn 'Quality setting must be between 0 and 100, or negative for lossless optimization'
+      else
+        system "#{jpeg_optimizer_bin} -f --strip-all --max=#{quality} --all-progressive #{path}"
+      end
+    end  
 
     def jpeg_optimizer_present?
       !jpeg_optimizer_bin.nil? && !jpeg_optimizer_bin.empty?


### PR DESCRIPTION
Depending on formatting of the original image, slight lossy optimization can provide huge file-size savings over strictly lossless JPEG compression. This update adds an optional 'quality' param that can be sent along with the source image path.

Optimizer will default to lossless compression if no quality param is specified, this change will not break existing implementations of the optimizer. Updates jpegoptim command line calls to force Progressive JPG output, as they provide a better end-user experience when loading over a slow connection. PNG optimization untouched; PNGs will ignore the quality param. Readme updated to reflect new options and defaults.
