### PR TITLE
Configurable optimization level

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,20 @@ optimization. PNGs will ignore the quality setting.
 ImageOptimizer.new('path/to/file.jpg', quality: 80).optimize
 ```
 
+##### Custom PNG optimization quality
+
+By default, `optipng` is called with the `-o7` flag, which controls the level of
+optimization. This default level generates the most optimized results, at the
+expense of very high execution times, so you may want to lower it if your server
+can't handle it.
+
+You can pass an optional `level` parameter to change this value. the JPEG
+optimizer will ignore the value.
+
+```ruby
+ImageOptimizer.new('path/to/file.png', level: 3).optimize
+```
+
 ##### Use identify
 
 Pass an optional `identify` parameter to identify file types using ImageMagick or GraphicsMagick `identify`

--- a/lib/image_optimizer/png_optimizer.rb
+++ b/lib/image_optimizer/png_optimizer.rb
@@ -4,9 +4,13 @@ class ImageOptimizer
   private
 
     def command_options
-      flags = %w[-o7]
+      flags = %W[-o#{level}]
       flags << quiet if options[:quiet]
       flags << path
+    end
+
+    def level
+      options[:level] || 7
     end
 
     def quiet

--- a/spec/image_optimizer/png_optimizer_spec.rb
+++ b/spec/image_optimizer/png_optimizer_spec.rb
@@ -39,7 +39,23 @@ describe ImageOptimizer::PNGOptimizer do
           subject
         end
       end
+
+      context 'without optimization parameter' do
+        it 'optimizes the png with level 7 optimization' do
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '/path/to/file.png')
+          subject
+        end
+      end
+
+      context 'with optimization parameter' do
+        let(:options) { { level: 3 } }
+        it 'optimizes the png with the requested optimization level' do
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o3', '/path/to/file.png')
+          subject
+        end
+      end
     end
+
 
     context 'with png optimizing utility not installed' do
       before do


### PR DESCRIPTION
The machine I'm using is to slow to use the default level 7 optimization with enough speed, so I need to configure this to use a lower level, which the gem currently doesn't seem to support