### PR TITLE
Use the -strip flag for even smaller files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ rbx-2.2.0, and ree
 ## Installation
 
 ##### This gem uses the following utilities for optimizing images:
-    
+
 1. jpegoptim, which can be installed from [freecode.com](http://freecode.com/projects/jpegoptim)
 
 2. OptiPNG, which can be installed from [sourceforge.net](http://optipng.sourceforge.net/)
 
-Or install the utilities via homebrew: 
+Or install the utilities via homebrew:
 
 ```bash
 $ brew install optipng jpegoptim
@@ -96,6 +96,18 @@ optimizer will ignore the value.
 
 ```ruby
 ImageOptimizer.new('path/to/file.png', level: 3).optimize
+```
+
+##### Don't Remove metadata from PNG
+
+By default, `optipng` is called with the `-strip all` flag, which removes all the
+level of metadata. This default generates the most optimized results.
+
+You can skip removing the meta data by changing the `strip_metadata` parameter to
+`false`. the JPEG optimizer will ignore the value.
+
+```ruby
+ImageOptimizer.new('path/to/file.png', strip_metadata: false).optimize
 ```
 
 ##### Use identify

--- a/lib/image_optimizer/png_optimizer.rb
+++ b/lib/image_optimizer/png_optimizer.rb
@@ -5,12 +5,22 @@ class ImageOptimizer
 
     def command_options
       flags = %W[-o#{level}]
+      flags << strip_metadata if strip_metadata?
       flags << quiet if options[:quiet]
       flags << path
     end
 
     def level
       options[:level] || 7
+    end
+
+    def strip_metadata
+      '-strip all'
+    end
+
+    def strip_metadata?
+      return options[:strip_metadata] if options.key? :strip_metadata
+      true
     end
 
     def quiet

--- a/spec/image_optimizer/png_optimizer_spec.rb
+++ b/spec/image_optimizer/png_optimizer_spec.rb
@@ -13,7 +13,7 @@ describe ImageOptimizer::PNGOptimizer do
       end
 
       it 'optimizes the png' do
-        expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '/path/to/file.png')
+        expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '-strip all', '/path/to/file.png')
         subject
       end
 
@@ -27,7 +27,7 @@ describe ImageOptimizer::PNGOptimizer do
         end
 
         it 'detects if there is an ENV variable path to optipng' do
-          expect(png_optimizer).to receive(:system).with(image_optim_optipng_bin_path, '-o7', '/path/to/file.png')
+          expect(png_optimizer).to receive(:system).with(image_optim_optipng_bin_path, '-o7', '-strip all', '/path/to/file.png')
           subject
         end
       end
@@ -35,14 +35,14 @@ describe ImageOptimizer::PNGOptimizer do
       context 'with quiet parameter' do
         let(:options) { { :quiet => true } }
         it 'optimizes the png' do
-          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '-quiet', '/path/to/file.png')
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '-strip all', '-quiet', '/path/to/file.png')
           subject
         end
       end
 
       context 'without optimization parameter' do
         it 'optimizes the png with level 7 optimization' do
-          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '/path/to/file.png')
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '-strip all', '/path/to/file.png')
           subject
         end
       end
@@ -50,7 +50,15 @@ describe ImageOptimizer::PNGOptimizer do
       context 'with optimization parameter' do
         let(:options) { { level: 3 } }
         it 'optimizes the png with the requested optimization level' do
-          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o3', '/path/to/file.png')
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o3', '-strip all', '/path/to/file.png')
+          subject
+        end
+      end
+
+      context 'without strip metadata objects parameter' do
+        let(:options) { { strip_metadata: false } }
+        it 'removes the requested metadata objects from the png' do
+          expect(png_optimizer).to receive(:system).with('/usr/local/bin/optipng', '-o7', '/path/to/file.png')
           subject
         end
       end


### PR DESCRIPTION
We use this gem when uploading files to our CMS.

Sadly, the png-files are still to big for google (even if we use the "save for web" option in photoshop)

I found out that we use optipng with the `-strip all` option (remove all metadata) when we optimize local images, and that this gem does not.

These are 3 test files, that where optimized without removing the metadata:
![screen shot 2016-09-14 at 08 26 45](https://cloud.githubusercontent.com/assets/7486464/18504999/4bde339e-7a65-11e6-9b52-c54051dc7f16.png)

These are the same 3 test files, that where optimized with removing the metadata:
![screen shot 2016-09-14 at 09 37 37](https://cloud.githubusercontent.com/assets/7486464/18505022/7e3e4b30-7a65-11e6-9ff1-fd95c85bb0c6.png)

And this are the images as google creates them "Optimized"
![screen shot 2016-09-14 at 10 26 32](https://cloud.githubusercontent.com/assets/7486464/18505062/c3ed25f2-7a65-11e6-8011-8f66a547120b.png)

As you can see, removing the meta data is the "missing" option to please google ;)