### PR TITLE
change name for level option for gif optimization

### DIFF
--- a/lib/image_optimizer/gif_optimizer.rb
+++ b/lib/image_optimizer/gif_optimizer.rb
@@ -9,7 +9,7 @@ class ImageOptimizer
     end
 
     def level
-      options[:level] || 1
+      options[:gif_level] || 1
     end
 
     def type

--- a/spec/image_optimizer/gif_optimizer_spec.rb
+++ b/spec/image_optimizer/gif_optimizer_spec.rb
@@ -33,14 +33,14 @@ describe ImageOptimizer::GIFOptimizer do
       end
 
       context 'without optimization parameter' do
-        it 'optimizes the gif with level 7 optimization' do
+        it 'optimizes the gif with level 1 optimization' do
           expect(gif_optimizer).to receive(:system).with('/usr/local/bin/gifsicle', '-b', '-O1', '/path/to/file.gif')
           subject
         end
       end
 
       context 'with optimization parameter' do
-        let(:options) { { level: 2 } }
+        let(:options) { { gif_level: 2 } }
         it 'optimizes the gif with the requested optimization level' do
           expect(gif_optimizer).to receive(:system).with('/usr/local/bin/gifsicle', '-b', '-O2', '/path/to/file.gif')
           subject


### PR DESCRIPTION
when you call optimized method, you don't know what type of image it is, and level option for png and  level option for gif should have different name