### PR TITLE
Fixes PNGQuant unrecognised error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## NEXT
+* Fix PNGQuantOptimizer `Unrecognised option` error - https://github.com/jtescher/image_optimizer/issues/17

--- a/lib/image_optimizer/pngquant_optimizer.rb
+++ b/lib/image_optimizer/pngquant_optimizer.rb
@@ -3,6 +3,10 @@ class ImageOptimizer
 
   private
 
+    def perform_optimizations
+      system("#{optimizer_bin} #{command_options.join(' ')}")
+    end
+
     def command_options
       flags = ['--skip-if-larger', '--speed 1',
                '--force', '--verbose', '--ext .png']

--- a/spec/image_optimizer/pngquant_optimizer_spec.rb
+++ b/spec/image_optimizer/pngquant_optimizer_spec.rb
@@ -13,8 +13,8 @@ describe ImageOptimizer::PNGQuantOptimizer do
       end
 
       it 'optimizes the png' do
-        optimizer_options = %w[--skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png]
-        expect(pngquant_optimizer).to receive(:system).with('/usr/local/bin/pngquant', *optimizer_options)
+        expected_cmd = "/usr/local/bin/pngquant --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png"
+        expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
         subject
       end
 
@@ -28,18 +28,18 @@ describe ImageOptimizer::PNGQuantOptimizer do
         end
 
         it 'should optimize using the given path' do
-          optimizer_options = %w[--skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png]
-          expect(pngquant_optimizer).to receive(:system).with(image_pngquant_bin_path, *optimizer_options)
+          expected_cmd = "#{image_pngquant_bin_path} --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png"
+          expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
           subject
         end
       end
 
       context 'with quality parameter' do
-        let(:options) { { :quality => 100 } }
+        let(:options) { { :quality => 99 } }
 
         it 'optimizes the png with the quality' do
-          optimizer_options = %w[--skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png]
-          expect(pngquant_optimizer).to receive(:system).with('/usr/local/bin/pngquant', *optimizer_options)
+          expected_cmd = "/usr/local/bin/pngquant --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 99 /path/to/file.png"
+          expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
           subject
         end
       end


### PR DESCRIPTION
This PR fixes the PNGQuant `Unrecognised option` error which occurs when trying to optimize using `PNGQuantOptimizer` as mentioned in #17.

* Added a changelog (seperate commit if it's unwanted). Typically for a changelog NEXT would be displayed up until release process then it would be changed to something like ` <version> (MMM DD, YYYY)`
* Updated the quality parameter spec as this could have been a half positive as it was passing in the default value.

