### PR TITLE
Fix: space in file name will break PNGQuantOptimizer

### DIFF
--- a/lib/image_optimizer/pngquant_optimizer.rb
+++ b/lib/image_optimizer/pngquant_optimizer.rb
@@ -3,13 +3,9 @@ class ImageOptimizer
 
   private
 
-    def perform_optimizations
-      system("#{optimizer_bin} #{command_options.join(' ')}")
-    end
-
     def command_options
-      flags = ['--skip-if-larger', '--speed 1',
-               '--force', '--verbose', '--ext .png']
+      flags = ['--skip-if-larger', '--speed=1',
+               '--force', '--verbose', '--ext=.png']
 
       flags -= ['--verbose'] if quiet?
       flags << quality
@@ -17,8 +13,8 @@ class ImageOptimizer
     end
 
     def quality
-      return "--quality 100" unless (0..100).include?(options[:quality])
-      "--quality #{options[:quality]}"
+      return "--quality=100" unless (0..100).include?(options[:quality])
+      "--quality=#{options[:quality]}"
     end
 
     def extensions

--- a/spec/image_optimizer/pngquant_optimizer_spec.rb
+++ b/spec/image_optimizer/pngquant_optimizer_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe ImageOptimizer::PNGQuantOptimizer do
   describe '#optimize' do
     let(:options) { {} }
-    let(:pngquant_optimizer) { ImageOptimizer::PNGQuantOptimizer.new('/path/to/file.png', options) }
+    let(:path) { '/path/to/file.png' }
+    let(:pngquant_optimizer) { ImageOptimizer::PNGQuantOptimizer.new(path, options) }
     after { ImageOptimizer::PNGQuantOptimizer.instance_variable_set(:@bin, nil) }
     subject { pngquant_optimizer.optimize }
 
@@ -13,8 +14,8 @@ describe ImageOptimizer::PNGQuantOptimizer do
       end
 
       it 'optimizes the png' do
-        expected_cmd = "/usr/local/bin/pngquant --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png"
-        expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
+        expected_cmd = %w[/usr/local/bin/pngquant --skip-if-larger --speed=1 --force --verbose --ext=.png --quality=100 /path/to/file.png]
+        expect(pngquant_optimizer).to receive(:system).with(*expected_cmd)
         subject
       end
 
@@ -28,8 +29,8 @@ describe ImageOptimizer::PNGQuantOptimizer do
         end
 
         it 'should optimize using the given path' do
-          expected_cmd = "#{image_pngquant_bin_path} --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 100 /path/to/file.png"
-          expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
+          expected_cmd = %w[--skip-if-larger --speed=1 --force --verbose --ext=.png --quality=100 /path/to/file.png]
+          expect(pngquant_optimizer).to receive(:system).with(image_pngquant_bin_path, *expected_cmd)
           subject
         end
       end
@@ -38,8 +39,8 @@ describe ImageOptimizer::PNGQuantOptimizer do
         let(:options) { { :quality => 99 } }
 
         it 'optimizes the png with the quality' do
-          expected_cmd = "/usr/local/bin/pngquant --skip-if-larger --speed\ 1 --force --verbose --ext\ .png --quality\ 99 /path/to/file.png"
-          expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
+          expected_cmd = %w[/usr/local/bin/pngquant --skip-if-larger --speed=1 --force --verbose --ext=.png --quality=99 /path/to/file.png]
+          expect(pngquant_optimizer).to receive(:system).with(*expected_cmd)
           subject
         end
       end
@@ -48,8 +49,18 @@ describe ImageOptimizer::PNGQuantOptimizer do
         let(:options) { { :quiet => true } }
 
         it 'optimizes the png with the quality' do
-          expected_cmd = "/usr/local/bin/pngquant --skip-if-larger --speed\ 1 --force --ext\ .png --quality\ 100 /path/to/file.png"
-          expect(pngquant_optimizer).to receive(:system).with(expected_cmd)
+          expected_cmd = %w[/usr/local/bin/pngquant --skip-if-larger --speed=1 --force --ext=.png --quality=100 /path/to/file.png]
+          expect(pngquant_optimizer).to receive(:system).with(*expected_cmd)
+          subject
+        end
+      end
+
+      context 'with space in file name' do
+        let(:path) { '/path/to/file 2.png' }
+
+        it do
+          expected_cmd = %w[/usr/local/bin/pngquant --skip-if-larger --speed=1 --force --verbose --ext=.png --quality=100]
+          expect(pngquant_optimizer).to receive(:system).with(*expected_cmd, path)
           subject
         end
       end


### PR DESCRIPTION
## Reproducing steps

Have a space in the file name: `2-4 3.png`
```rb
ImageOptimizer::PNGQuantOptimizer.new('./spec/fixtures/files/2-4 3.png').optimize
```
It will be regarded as two images input, `2.4`, `3.png`, which causes errors.
```
./spec/fixtures/files/2-4:
  error: cannot open ./spec/fixtures/files/2-4 for reading
3.png:
  error: cannot open 3.png for reading
There were errors quantizing 2 files out of a total of 2 files.
```

`perform_optimizations` method, added in #17, is removed to fix this bug. 
And the bug fixed in #17 is fixed by changing `'--speed 1'` to `'--speed=1'`